### PR TITLE
resolve search results battle

### DIFF
--- a/client/src/components/Room/RoomView.jsx
+++ b/client/src/components/Room/RoomView.jsx
@@ -10,7 +10,8 @@ import Search from './Search';
 import SearchResults from './SearchResults';
 import sampleVideoData from '../../../../db/sampleVideoData';
 
-const socket = io.connect(window.location.hostname || 'localhost:8080');
+// const socket = io.connect(window.location.hostname);
+const socket = io.connect('localhost:8080');
 
 class RoomView extends React.Component {
   constructor(props) {
@@ -30,12 +31,12 @@ class RoomView extends React.Component {
     this.renderPlaylist();
     socket.on('retrievePlaylist', videos => this.setState({ playlist: videos }));
     socket.on('error', err => console.error(err));
-    socket.on('searchResults', ({ items }) => {
-      this.setState({
-        searchResults: items,
-        query: '',
-      });
-    });
+    // socket.on('searchResults', ({ items }) => {
+    //   this.setState({
+    //     searchResults: items,
+    //     query: '',
+    //   });
+    // });
   }
 
   updateQuery(event) {
@@ -48,8 +49,14 @@ class RoomView extends React.Component {
   }
 
   // send query to server via socket connection
-  search() { socket.emit('youtubeSearch', this.state.query); }
+  search() { 
+    axios.get(`/search?query=${this.state.query}`)
+      .then(videos => this.state.searchResults = videos.data.items)
+      .catch(err => console.error('Failed to get videos: ', err));
+  }
+
   saveToPlaylist(video) { socket.emit('saveToPlaylist', video); }
+
   renderPlaylist() {
     return axios.get('/renderPlaylist')
       .then(response => this.setState({ playlist: response.data }))

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -30,7 +30,7 @@ const Room = sequelize.define('room', {
 //     videoName: 'sample video name',
 //     creator: 'sample video creator',
 //     url: 'sample url',
-//     duration: '1231',
+//     description: '1231',
 //   });
 // });
 

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,12 @@ app.get('/renderPlaylist', (req, res) => {
     .then(videos => res.json(videos));
 });
 
+app.get('/search', (req, res) => {
+  youtubeApi.grabVideos(req.query.query)
+    .then(searchResults => res.json(searchResults))
+    .catch(err => res.sendStatus(404));
+});
+
 io.on('connection', (socket) => {
   console.log('connected to client');
 
@@ -27,11 +33,11 @@ io.on('connection', (socket) => {
   };
 
   // listen for incoming youtube searches
-  socket.on('youtubeSearch', (query) => {
-    youtubeApi.grabVideos(query)
-      .then(videos => io.emit('searchResults', videos))
-      .catch(err => io.emit('error', err));
-  });
+  // socket.on('youtubeSearch', (query) => {
+  //   youtubeApi.grabVideos(query)
+  //     .then(videos => io.emit('searchResults', videos))
+  //     .catch(err => io.emit('error', err));
+  // });
 
   socket.on('saveToPlaylist', (video) => {
     const videoData = {


### PR DESCRIPTION
ended the socket relationship with search results. now when a user searches it is just handled on their own client. left the previous code commented out and not deleted just in case, but pretty sure we have no use for it anymore.

fixed nick's room schema modification to include description instead of duration in the sample entry.

lines 13 and 14 in RoomView.jsx need to be toggled when working locally vs herokully.

